### PR TITLE
Create github action to run pre-commit and snakemake on repo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Install snakemake
-        run: conda install -y -c bioconda 'snakemake>=8.18.2,<9'
+        run: conda install -y -c bioconda -c conda-forge 'snakemake>=8.18.2,<9' 'python=3.12'
 
       - name: Run Snakemake
         run: snakemake --cores=1 --sdm=conda --conda-cleanup-pkgs=cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,19 +12,29 @@ jobs:
     - uses: pre-commit/action@v3.0.1
   test:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     steps:
-      - name: Setup Miniconda
-        uses: conda-incubator/setup-miniconda@v3.0.4
-        with:
-          miniforge-version: "latest"
-          activate-environment: snakemake
-
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install snakemake
-        run: conda install -y -c bioconda -c conda-forge 'snakemake>=8.18.2,<9' 'python=3.12'
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v3.0.4
+        with:
+          python-version: '3.12'
+          channels: bioconda,conda-forge
+          channel-priority: true
+          miniforge-version: "latest"
+          activate-environment: snakemake
 
-      - name: Run Snakemake
-        shell: bash -el {0}
-        run: snakemake --cores=1 --sdm=conda --conda-cleanup-pkgs=cache
+      - name: TMP
+        run: |
+            echo $CONDA_PREFIX
+            echo $PATH
+
+      - name: Snakemake
+        run: |
+          conda install -y -c bioconda -c conda-forge 'snakemake>=8.18.2,<9' 'python=3.12'
+          snakemake --cores=1 --sdm=conda --conda-cleanup-pkgs=cache
+

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,9 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-    - name: snakemake
-      uses: snakemake/snakemake-github-action@v1.25.1
-      with:
-        snakefile: workflow/Snakefile
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Snakemake
+        uses: snakemake/snakemake-github-action@v1.25.1
+        with:
+          snakefile: workflow/Snakefile

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,3 +19,5 @@ jobs:
         uses: snakemake/snakemake-github-action@v1.25.1
         with:
           snakefile: workflow/Snakefile
+          args:
+            "--config config/config.yaml"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,4 +19,5 @@ jobs:
         uses: snakemake/snakemake-github-action@v1.25.1
         with:
           directory: '.'
+          snakefile: 'workflow/Snakefile'
           args: '--cores=1 --sdm=conda --conda-cleanup-pkgs=cache'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,4 +21,4 @@ jobs:
           directory: '.'
           snakefile: 'workflow/Snakefile'
           args: '--cores=1 --sdm=conda --conda-cleanup-pkgs=cache'
-          stagein: 'apt-get update && apt-get install libgl1'
+          stagein: 'sudo apt-get update && sudo apt-get install libgl1'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - uses: actions/setup-python@v3
     - uses: pre-commit/action@v3.0.1
   test:
@@ -17,7 +17,7 @@ jobs:
         shell: bash -l {0}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Miniconda
         uses: conda-incubator/setup-miniconda@v3.0.4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,17 +24,13 @@ jobs:
         with:
           python-version: '3.12'
           channels: bioconda,conda-forge
-          channel-priority: true
+          channel-priority: strict
           miniforge-version: "latest"
           activate-environment: snakemake
 
-      - name: TMP
-        run: |
-            echo $CONDA_PREFIX
-            echo $PATH
+      - name: Install Snakemake
+        run: conda install -y -c bioconda -c conda-forge 'snakemake>=8.18.2,<9' 'python=3.12'
 
-      - name: Snakemake
-        run: |
-          conda install -y -c bioconda -c conda-forge 'snakemake>=8.18.2,<9' 'python=3.12'
-          snakemake --cores=1 --sdm=conda --conda-cleanup-pkgs=cache
+      - name: Run Snakemake
+        run: snakemake --cores=1 --sdm=conda --conda-cleanup-pkgs=cache
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,12 +13,16 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Miniconda
+        uses: conda-incubator/setup-miniconda@v3.0.4
+        with:
+          miniforge-version: "latest"
+          conda-solver: "libmamba"
+
       - name: Checkout
         uses: actions/checkout@v3
+
       - name: Snakemake
-        uses: snakemake/snakemake-github-action@v1.25.1
-        with:
-          directory: '.'
-          snakefile: 'workflow/Snakefile'
-          args: '--cores=1 --sdm=conda --conda-cleanup-pkgs=cache'
-          stagein: 'sudo apt-get update && sudo apt-get install libgl1'
+        run: |
+          conda install -y -c bioconda snakemake
+          snakemake --cores=1 --sdm=conda --conda-cleanup-pkgs=cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,12 +17,13 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3.0.4
         with:
           miniforge-version: "latest"
-          conda-solver: "libmamba"
+          activate-environment: snakemake
 
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Snakemake
-        run: |
-          conda install -y -c bioconda snakemake
-          snakemake --cores=1 --sdm=conda --conda-cleanup-pkgs=cache
+      - name: Install snakemake
+        run: conda install -y -c bioconda 'snakemake>=8.18.2,<9'
+
+      - name: Run Snakemake
+        run: snakemake --cores=1 --sdm=conda --conda-cleanup-pkgs=cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,5 @@ jobs:
       - name: Snakemake
         uses: snakemake/snakemake-github-action@v1.25.1
         with:
-          directory: '.test'
-          snakefile: 'workflow/Snakefile'
-          args: '--cores=1 --config=config/config.yaml --sdm=conda --conda-cleanup-pkgs=cache'
+          directory: '.'
+          args: '--cores=1 --sdm=conda --conda-cleanup-pkgs=cache'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,3 +21,4 @@ jobs:
           directory: '.'
           snakefile: 'workflow/Snakefile'
           args: '--cores=1 --sdm=conda --conda-cleanup-pkgs=cache'
+          stagein: 'apt-get update && apt-get install libgl1'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,17 @@
+name: main
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.1
+  test:
+    runs-on: ubuntu-latest
+    steps:  
+    - name: snakemake
+      uses: snakemake/snakemake-github-action@v1.25.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,6 @@ jobs:
       - name: Snakemake
         uses: snakemake/snakemake-github-action@v1.25.1
         with:
-          snakefile: workflow/Snakefile
-          args:
-            "--config config/config.yaml"
+          directory: '.test'
+          snakefile: 'workflow/Snakefile'
+          args: '--cores=1 --config=config/config.yaml --sdm=conda --conda-cleanup-pkgs=cache'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,12 +24,11 @@ jobs:
         with:
           python-version: '3.12'
           channels: bioconda,conda-forge
-          channel-priority: strict
           miniforge-version: "latest"
           activate-environment: snakemake
 
       - name: Install Snakemake
-        run: conda install -y -c bioconda -c conda-forge 'snakemake>=8.18.2,<9' 'python=3.12'
+        run: conda install -y 'snakemake>=8.18.2,<9' 'python=3.12'
 
       - name: Run Snakemake
         run: snakemake --cores=1 --sdm=conda --conda-cleanup-pkgs=cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,4 +26,5 @@ jobs:
         run: conda install -y -c bioconda -c conda-forge 'snakemake>=8.18.2,<9' 'python=3.12'
 
       - name: Run Snakemake
+        shell: bash -el {0}
         run: snakemake --cores=1 --sdm=conda --conda-cleanup-pkgs=cache

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,8 @@ jobs:
     - uses: pre-commit/action@v3.0.1
   test:
     runs-on: ubuntu-latest
-    steps:  
+    steps:
     - name: snakemake
       uses: snakemake/snakemake-github-action@v1.25.1
+      with:
+        snakefile: workflow/Snakefile


### PR DESCRIPTION
The "old" pre-commit action is used here; it is simple, does what we want and doesn't involve external services or authentication. (Those things are needed to apply fixes automatically.)

Here I tried to use the official [snakemake-github-action](https://github.com/snakemake/snakemake-github-action) but unfortunately it doesn't play nicely with Mantid. The problem is that it uses a Docker container that lacks a LibGL dependency. There isn't a straightforward way to use apt in the container with appropriate permissions. So instead I go for a basic miniconda setup, running on the Github runner which has no such issue.